### PR TITLE
Adding check if sku has temporary drive, before applying change

### DIFF
--- a/DscResources/xAzureTempDrive/xAzureTempDrive.psm1
+++ b/DscResources/xAzureTempDrive/xAzureTempDrive.psm1
@@ -42,7 +42,8 @@ function Set-TargetResource
   ) 
 
   # Check to see if we are on a sku that can have drive re-mapped
-  if(hasTemporaryDrive -eq $false) {
+  $hasTempDrive = hasTemporaryDrive
+  if($hasTempDrive -eq $false) {
     Write-Verbose "Not-supported sku for drive re-mapping"
     return $true
   }
@@ -91,7 +92,8 @@ function Test-TargetResource
   ) 
 
   # Check to see if we are on a sku that can have drive re-mapped
-  if(hasTemporaryDrive -eq $false) {
+  $hasTempDrive = hasTemporaryDrive
+  if($hasTempDrive -eq $false) {
     Write-Verbose "Not-supported sku for drive re-mapping"
     return $true
   }

--- a/DscResources/xAzureTempDrive/xAzureTempDrive.psm1
+++ b/DscResources/xAzureTempDrive/xAzureTempDrive.psm1
@@ -1,14 +1,14 @@
 ﻿# Find out if we are on a VM that has a temporary drive can be moved
 # e.g. DS1 series has a temp drive, while DS2 series does not
 function hasTemporaryDrive {
-  $pageFileDrive = Get-CimInstance -ClassName win32_pagefilesetting | Select-Object -Property Name -ExpandProperty Name
-  if ($pageFileDrive -ieq 'C:\') {
-    # Page file is on C: drive so unsupported sku
-    return $false
-  } else {
-    # Page file not on C: drive so using sku with temporary drives
-    return $true
+  # Check to see if there are any disks labelled as Temporary Storage
+  $volumes = Get-Volume
+  foreach ($volume in $volumes) {
+      if ($volume.FileSystemLabel -eq "Temporary Storage") {
+          return $true
+      }
   }
+  return $false
 }
 
 function Get-TargetResource 


### PR DESCRIPTION
The current `xAzureTempDrive` does not work with newer Azure skus that don't have a temporary drive. When running this DSC on these skus I get an exception when running the `Test-TargetResource` method.

`“The PowerShell DSC resource '[xAzureTempDrive]AzureTempDrive' with SourceInfo '::58::9::xAzureTempDrive' threw one or more non-terminating errors while running the Test-TargetResource functionality. These errors are logged to the ETW channel called Microsoft-Windows-DSC/Operational. Refer to this channel for more details.”` 

I have added a `hasTemporaryDrive` method to this module that checks the location of the Page File, and if it is on the C:/ drive assumes it is an unsupported sku and bypasses the `Set-TargetResource` and `Test-TargetResource`. I've developed this change as I have an issue where I need to apply the same DSC independent of sku type.